### PR TITLE
Get HAPI datasets and resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 requires-python = ">=3.8"
 
 dependencies = [
-    "hdx-python-scraper >= 2.1.8",
+    "hdx-python-scraper@git+ssh://git@github.com/OCHA-DAP/hdx-python-scraper@hapi_metadata#egg=hdx-python-scraper",
     "hdx-python-database[postgresql]>= 1.2.5",
 ]
 dynamic = ["version"]
@@ -62,6 +62,9 @@ packages = ["src/hapi"]
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/hapi/pipelines._version.py"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 # Versioning
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = ["pre-commit"]
 packages = ["src/hapi"]
 
 [tool.hatch.build.hooks.vcs]
-version-file = "src/hapi/pipelines._version.py"
+version-file = "src/hapi/pipelines/_version.py"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,19 +71,19 @@ greenlet==2.0.2
     # via sqlalchemy
 gspread==5.10.0
     # via hdx-python-scraper
-hdx-python-api==6.0.8
+hdx-python-api==6.0.9
     # via hdx-python-scraper
 hdx-python-country==3.5.2
     # via hdx-python-api
 hdx-python-database[postgresql]==1.2.5
     # via hapi-pipelines (pyproject.toml)
-hdx-python-scraper==2.1.8
+hdx-python-scraper @ git+ssh://git@github.com/OCHA-DAP/hdx-python-scraper@hapi_metadata
     # via hapi-pipelines (pyproject.toml)
 hdx-python-utilities==3.6.2
     # via hdx-python-country
 humanize==4.8.0
     # via frictionless
-identify==2.5.26
+identify==2.5.27
     # via pre-commit
 idna==3.4
     # via
@@ -135,7 +135,7 @@ packaging==23.1
     # via pytest
 paramiko==3.3.1
     # via sshtunnel
-petl==1.7.13
+petl==1.7.14
     # via frictionless
 platformdirs==3.10.0
     # via virtualenv
@@ -163,11 +163,11 @@ pyasn1-modules==0.3.0
     # via google-auth
 pycparser==2.21
     # via cffi
-pydantic==2.2.0
+pydantic==2.2.1
     # via
     #   frictionless
     #   inflect
-pydantic-core==2.6.0
+pydantic-core==2.6.1
     # via pydantic
 pygments==2.16.1
     # via rich
@@ -285,7 +285,7 @@ validators==0.21.2
     # via frictionless
 virtualenv==20.24.3
     # via pre-commit
-wheel==0.41.1
+wheel==0.41.2
     # via libhxl
 xlrd==2.0.1
     # via hdx-python-utilities

--- a/src/hapi/pipelines/app/pipelines.py
+++ b/src/hapi/pipelines/app/pipelines.py
@@ -68,7 +68,10 @@ class Pipelines:
         self.runner.get_results()
         #  Transform and write the results to population schema in db
         #  We need mapping from HXL hashtags in results to gender and age range codes
-        #  Probably should expand scraper framework to pull out all the resource stuff below (as well as dataset info)...
+
+        self.runner.get_hapi_metadata()
+        # Gets Datasets and Resources
+
         #  Need to fix fake dataset_ref below once we have a dataset table
         dbresource = DBResource(
             code="e8f7fb08-af9c-4bdf-8a49-a54c56a4a1b0",


### PR DESCRIPTION
Scraper framework now supplies get_hapi_metadata which gives datasets abd resources for DB
However I don't knwo how to supply git+ssh://git@github.com/OCHA-DAP/hdx-python-scraper@hapi_metadata#egg=hdx-python-scraper in pyproject.toml so that pre-commit works