### PR TITLE
Add resource and dataset data with table reflection

### DIFF
--- a/.config/pre-commit-config.yaml
+++ b/.config/pre-commit-config.yaml
@@ -1,6 +1,12 @@
 default_language_version:
     python: python3.11
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-ast
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,9 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+## Project
+# DB
+hapi.db
+# Version file
+src/hapi/pipelines._version.py

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ humanitarian related data, please upload your datasets to HDX.
 
 ## Running
 
+Ensure the `hapi` library is installed using `pip install .`.
+
 Use the
 [HAPI schema repository](https://github.com/OCHA-DAP/hapi-schemas)
 to create a SQLite HAPI database. Point to the file
 `hapi-schemas/databases/hapi-test.sqlite` when executing:
 
 ```shell
-python src/hapi/pipelines/app/main.py --db "sqlite:///path-to-hapi-test.sqlite"
+python src/hapi/pipelines/app/__main__.py --db "sqlite:///path-to-hapi-test.sqlite"
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# HAPI Pipelines
+
 [![Build Status](https://github.com/OCHA-DAP/hapi-pipelines/actions/workflows/run-python-tests.yaml/badge.svg)](https://github.com/OCHA-DAP/hapi-pipelines/actions/workflows/run-python-tests.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/OCHA-DAP/hapi-pipelines/badge.svg?branch=main&ts=1)](https://coveralls.io/github/OCHA-DAP/hapi-pipelines?branch=main)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
@@ -7,5 +9,16 @@ HAPI is a process that runs ...
 
 For more information, please read the [documentation](https://hapi-pipelines.readthedocs.io/en/latest/).
 
-This library is part of the [Humanitarian Data Exchange](https://data.humdata.org/) (HDX) project. If you have 
+This library is part of the [Humanitarian Data Exchange](https://data.humdata.org/) (HDX) project. If you have
 humanitarian related data, please upload your datasets to HDX.
+
+## Running
+
+Use the
+[HAPI schema repository](https://github.com/OCHA-DAP/hapi-schemas)
+to create a SQLite HAPI database. Point to the file
+`hapi-schemas/databases/hapi-test.sqlite` when executing:
+
+```shell
+python src/hapi/pipelines/app/main.py --db "sqlite:///path-to-hapi-test.sqlite"
+```

--- a/src/hapi/pipelines/app/__main__.py
+++ b/src/hapi/pipelines/app/__main__.py
@@ -16,32 +16,32 @@ from hdx.utilities.easy_logging import setup_logging
 from hdx.utilities.errors_onexit import ErrorsOnExit
 from hdx.utilities.path import script_dir_plus_file, temp_dir
 
-from .. import __version__
+from hapi.pipelines._version import __version__
 from hapi.pipelines.app.pipelines import Pipelines
 
 setup_logging()
 logger = logging.getLogger(__name__)
 
 
-lookup = "hapi-pipelines"
+lookup = "hapi-pipelines)"
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description="HAPI pipelines")
-    parser.add_argument("-hk", "--hdx_key", default=None, help="HDX api key")
-    parser.add_argument("-ua", "--user_agent", default=None, help="user agent")
+    parser.add_argument("-hk", "--hdx-key", default=None, help="HDX api key")
+    parser.add_argument("-ua", "--user-agent", default=None, help="user agent")
     parser.add_argument("-pp", "--preprefix", default=None, help="preprefix")
     parser.add_argument(
-        "-hs", "--hdx_site", default=None, help="HDX site to use"
+        "-hs", "--hdx-site", default=None, help="HDX site to use"
     )
     parser.add_argument(
-        "-db", "--db_uri", default=None, help="Database connection string"
+        "-db", "--db-uri", default=None, help="Database connection string"
     )
     parser.add_argument(
         "-dp",
-        "--db_params",
+        "--db-params",
         default=None,
-        help="Database connection parameters. Overrides --db_uri.",
+        help="Database connection parameters. Overrides --db-uri.",
     )
     parser.add_argument(
         "-sc", "--scrapers", default=None, help="Scrapers to run"
@@ -55,7 +55,7 @@ def parse_args():
     )
     parser.add_argument(
         "-usv",
-        "--use_saved",
+        "--use-saved",
         default=False,
         action="store_true",
         help="Use saved data",

--- a/src/hapi/pipelines/app/pipelines.py
+++ b/src/hapi/pipelines/app/pipelines.py
@@ -29,7 +29,7 @@ class Pipelines:
 
         Sources.set_default_source_date_format("%Y-%m-%d")
         self.runner = Runner(
-            configuration["countries"],
+            configuration["HRPs"],
             today,
             errors_on_exit=errors_on_exit,
             scrapers_to_run=scrapers_to_run,

--- a/src/hapi/pipelines/app/pipelines.py
+++ b/src/hapi/pipelines/app/pipelines.py
@@ -3,7 +3,7 @@ from hdx.location.country import Country
 from hdx.scraper.runner import Runner
 from hdx.scraper.utilities.sources import Sources
 
-from hapi.pipelines.database.dbresource import DBResource
+from hapi.pipelines.database.tables import Tables
 
 
 class Pipelines:
@@ -19,6 +19,7 @@ class Pipelines:
     ):
         self.configuration = configuration
         self.session = session
+        self.tables = Tables(self.session)
         self.use_live = use_live
         Country.countriesdata(
             use_live=use_live,
@@ -73,13 +74,13 @@ class Pipelines:
         # Gets Datasets and Resources
 
         #  Need to fix fake dataset_ref below once we have a dataset table
-        dbresource = DBResource(
+        dbresource = self.tables.Resource(
             code="e8f7fb08-af9c-4bdf-8a49-a54c56a4a1b0",
             dataset_ref=0,
             hdx_link="https://data.humdata.org/dataset/8520e386-9263-48c9-b1bf-b2349e019fbb/resource/e8f7fb08-af9c-4bdf-8a49-a54c56a4a1b0/download/col_admpop_adm1_2023.csv",
             filename="col_admpop_adm1_2023.csv",
-            mime_type="csv",
-            last_modified=self.runner.today,
+            format="csv",
+            update_date=self.runner.today,
             is_hxl=False,
             api_link="https://data.humdata.org/api/3/action/resource_show?id=e8f7fb08-af9c-4bdf-8a49-a54c56a4a1b0",
         )

--- a/src/hapi/pipelines/database/tables.py
+++ b/src/hapi/pipelines/database/tables.py
@@ -1,0 +1,36 @@
+from typing import Type
+
+from sqlalchemy.orm import Session, declarative_base
+
+_TABLE_NAMES = [
+    "Admin1",
+    "Admin2",
+    "AgeRange",
+    "Dataset",
+    "Gender",
+    "Location",
+    "OperationalPresence",
+    "Org",
+    "OrgType",
+    "Population",
+    "Resource",
+]
+
+
+class Tables:
+    def __init__(self, session: Session):
+        engine = session.get_bind()
+        Base = declarative_base()
+        Base.metadata.reflect(engine)
+
+        self.create_table_classes(Base)
+
+    @staticmethod
+    def create_table_classes(Base: Type[declarative_base()]):
+        for table_name in _TABLE_NAMES:
+            table_class = type(
+                table_name,
+                (Base,),
+                {"__table__": Base.metadata.tables[table_name]},
+            )
+            setattr(Tables, table_name, table_class)

--- a/src/hapi/pipelines/database/tables.py
+++ b/src/hapi/pipelines/database/tables.py
@@ -1,7 +1,10 @@
+"""Reflect and return the tables from the HAPI DB."""
+
 from typing import Type
 
 from sqlalchemy.orm import Session, declarative_base
 
+# Each time a new theme is added, add the tables here
 _TABLE_NAMES = [
     "Admin1",
     "Admin2",
@@ -14,20 +17,29 @@ _TABLE_NAMES = [
     "OrgType",
     "Population",
     "Resource",
+    "Sector",
 ]
 
 
 class Tables:
     def __init__(self, session: Session):
+        """
+        Reflect the tables from an existing DB.
+
+        Args:
+            session ():
+        """
         engine = session.get_bind()
         Base = declarative_base()
         Base.metadata.reflect(engine)
 
-        self.create_table_classes(Base)
+        self._create_table_classes(Base)
 
     @staticmethod
-    def create_table_classes(Base: Type[declarative_base()]):
+    def _create_table_classes(Base: Type[declarative_base()]):
         for table_name in _TABLE_NAMES:
+            # Create each class dynamically with table_name as the name,
+            # Base as the base, and dunder table from the Base metadata
             table_class = type(
                 table_name,
                 (Base,),


### PR DESCRIPTION
I've created the Tables class which uses reflection to generate the table format from David's schema database file. Note that (as of writing this) you will have to use the `autoincrement` branch of the repo for the code to run all the way through.

Then it populates the Resource and Dataset tables with the metadata from the runner. 

Other small changes:
- added a couple of handy pre-commits that I like to use
- moved .gitignore to top-level
- added run instructions to the README (am I running correctly? I had to change how the versions were imported to make it work)
- in the arg parser, changed long-form arguments with underscores to hyphens - the variable names in Python then automatically use underscores. Or do you prefer the arguments to have underscores Mike?