### PR TITLE
Bugfix: resource ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [0.1.1] - 2023-09-29
+
+### Fixed
+
+- Operational presence resource ref
+
 ## [0.1.0] - 2023-09-29
 
 ### Added

--- a/src/hapi/pipelines/app/pipelines.py
+++ b/src/hapi/pipelines/app/pipelines.py
@@ -120,7 +120,7 @@ class Pipelines:
         self.sector.populate()
         # TODO: make this a single scraper once metadata issue is solved
         for scraper in self.operational_presence:
-            scraper.populate()
+            scraper.populate(metadata=self.metadata)
         self.gender.populate()
         results = self.runner.get_hapi_results()
         population = Population(

--- a/src/hapi/pipelines/utilities/operational_presence.py
+++ b/src/hapi/pipelines/utilities/operational_presence.py
@@ -11,6 +11,7 @@ from hapi.pipelines.utilities.admins import (
     get_admin1_to_location_connector_code,
     get_admin2_to_admin1_connector_code,
 )
+from hapi.pipelines.utilities.metadata import Metadata
 from hapi.pipelines.utilities.org import Org
 from hapi.pipelines.utilities.org_type import OrgType
 from hapi.pipelines.utilities.sector import Sector
@@ -64,9 +65,11 @@ class OperationalPresence(BaseScraper):
         return
 
     # TODO: make this handle all countries once metadata issue is solved
-    def populate(self):
+    def populate(self, metadata: Metadata):
         logger.info("Populating operational presence table")
-        resource_ref = self.datasetinfo["hapi_resource_metadata"]["hdx_id"]
+        resource_ref = metadata.resource_data[
+            self.datasetinfo["hapi_resource_metadata"]["hdx_id"]
+        ]
         reference_period_start = self.datasetinfo["hapi_dataset_metadata"][
             "reference_period"
         ]["startdate"]
@@ -122,6 +125,7 @@ class OperationalPresence(BaseScraper):
                 # logger.error(
                 #    f"Sector {sector_name, sector_code} not in table"
                 # )
+                sector_code = 1
             if admin_level == "national":
                 admin1_code = get_admin1_to_location_connector_code(admin_code)
                 admin2_code = get_admin2_to_admin1_connector_code(admin1_code)

--- a/src/hapi/pipelines/utilities/operational_presence.py
+++ b/src/hapi/pipelines/utilities/operational_presence.py
@@ -125,7 +125,6 @@ class OperationalPresence(BaseScraper):
                 # logger.error(
                 #    f"Sector {sector_name, sector_code} not in table"
                 # )
-                sector_code = 1
             if admin_level == "national":
                 admin1_code = get_admin1_to_location_connector_code(admin_code)
                 admin2_code = get_admin2_to_admin1_connector_code(admin1_code)


### PR DESCRIPTION
Just a small bug in the resource ref - caught when I tried to populate a PostgreSQL table (sqlite doesn't care). It's not a beautiful solution because the custom scraper behaves a bit different w.r.t. the metadata