### PR TITLE
Possible way to modify add_configurables

### DIFF
--- a/src/hapi/pipelines/app/pipelines.py
+++ b/src/hapi/pipelines/app/pipelines.py
@@ -78,7 +78,11 @@ class Pipelines:
                 admin_sources=True,
                 adminlevel=adminlevel,
             )
-            self.configurable_scrapers[prefix] = self.runner.add_configurables(
+            self.configurable_scrapers[
+                prefix
+            ] = self.configurable_scrapers.get(
+                prefix, []
+            ) + self.runner.add_configurables(
                 self.configuration[f"{prefix}{suffix}"],
                 level,
                 adminlevel=adminlevel,


### PR DESCRIPTION
The configurable scraper part of the pipelines setup is overwriting itself every time an admin level is added.  This is a way (admittedly not very elegant) to append keys to the configurable scrapers list instead of overwriting.  Feel free to modify into something nicer!