### PR TITLE
Prevent duplicate operation presence rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.3] - 2023-10-10
+
+### Fixed
+
+- Remove duplicates from operational presence
+
 ## [0.2.2] - 2023-10-06
 
 ### Fixed

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --all-extras --output-file=requirements.txt --resolver=backtracking pyproject.toml
 #
-annotated-types==0.5.0
+annotated-types==0.6.0
     # via pydantic
 attrs==23.1.0
     # via
@@ -257,7 +257,7 @@ sshtunnel==0.4.0
     # via hdx-python-database
 stringcase==1.2.0
     # via frictionless
-structlog==23.1.0
+structlog==23.2.0
     # via libhxl
 tableschema-to-template==0.0.13
     # via hdx-python-utilities
@@ -294,7 +294,7 @@ xlrd==2.0.1
     # via hdx-python-utilities
 xlrd3==1.1.0
     # via libhxl
-xlsxwriter==3.1.6
+xlsxwriter==3.1.7
     # via tableschema-to-template
 xlwt==1.3.0
     # via hdx-python-utilities

--- a/src/hapi/pipelines/app/pipelines.py
+++ b/src/hapi/pipelines/app/pipelines.py
@@ -78,17 +78,15 @@ class Pipelines:
                 admin_sources=True,
                 adminlevel=adminlevel,
             )
-            self.configurable_scrapers[
-                prefix
-            ] = self.configurable_scrapers.get(
-                prefix, []
-            ) + self.runner.add_configurables(
+            scrapers = self.runner.add_configurables(
                 self.configuration[f"{prefix}{suffix}"],
                 level,
                 adminlevel=adminlevel,
                 source_configuration=source_configuration,
                 suffix=suffix,
             )
+            cur_scrapers = self.configurable_scrapers.get(prefix, [])
+            self.configurable_scrapers[prefix] = cur_scrapers + scrapers
 
         _create_configurable_scrapers("population", "national")
         _create_configurable_scrapers(

--- a/src/hapi/pipelines/app/pipelines.py
+++ b/src/hapi/pipelines/app/pipelines.py
@@ -85,8 +85,8 @@ class Pipelines:
                 source_configuration=source_configuration,
                 suffix=suffix,
             )
-            cur_scrapers = self.configurable_scrapers.get(prefix, [])
-            self.configurable_scrapers[prefix] = cur_scrapers + scrapers
+            current_scrapers = self.configurable_scrapers.get(prefix, [])
+            self.configurable_scrapers[prefix] = current_scrapers + scrapers
 
         _create_configurable_scrapers("population", "national")
         _create_configurable_scrapers(

--- a/src/hapi/pipelines/database/operational_presence.py
+++ b/src/hapi/pipelines/database/operational_presence.py
@@ -37,6 +37,7 @@ class OperationalPresence(BaseUploader):
     def populate(self):
         logger.info("Populating operational presence table")
         rows = []
+        number_duplicates = 0
         for dataset in self._results.values():
             reference_period_start = dataset["reference_period"]["startdate"]
             reference_period_end = dataset["reference_period"]["enddate"]
@@ -137,6 +138,7 @@ class OperationalPresence(BaseUploader):
                         admin2_ref = self._admins.admin2_data[admin2_code]
                         row = (resource_ref, org_ref, sector_code, admin2_ref)
                         if row in rows:
+                            number_duplicates += 1
                             continue
                         rows.append(row)
                         operational_presence_row = DBOperationalPresence(
@@ -151,3 +153,6 @@ class OperationalPresence(BaseUploader):
                         )
                         self._session.add(operational_presence_row)
         self._session.commit()
+        logger.info(
+            f"There were {number_duplicates} duplicate operational presence rows!"
+        )

--- a/src/hapi/pipelines/database/operational_presence.py
+++ b/src/hapi/pipelines/database/operational_presence.py
@@ -36,6 +36,7 @@ class OperationalPresence(BaseUploader):
 
     def populate(self):
         logger.info("Populating operational presence table")
+        rows = []
         for dataset in self._results.values():
             reference_period_start = dataset["reference_period"]["startdate"]
             reference_period_end = dataset["reference_period"]["enddate"]
@@ -127,15 +128,22 @@ class OperationalPresence(BaseUploader):
                             )
                         elif admin_level == "admintwo":
                             admin2_code = admin_code
+                        resource_ref = self._metadata.resource_data[
+                            resource_id
+                        ]
+                        org_ref = self._org.data[
+                            (org_acronym, org_name, org_type_code)
+                        ]
+                        admin2_ref = self._admins.admin2_data[admin2_code]
+                        row = (resource_ref, org_ref, sector_code, admin2_ref)
+                        if row in rows:
+                            continue
+                        rows.append(row)
                         operational_presence_row = DBOperationalPresence(
-                            resource_ref=self._metadata.resource_data[
-                                resource_id
-                            ],
-                            org_ref=self._org.data[
-                                (org_acronym, org_name, org_type_code)
-                            ],
+                            resource_ref=resource_ref,
+                            org_ref=org_ref,
                             sector_code=sector_code,
-                            admin2_ref=self._admins.admin2_data[admin2_code],
+                            admin2_ref=admin2_ref,
                             reference_period_start=reference_period_start,
                             reference_period_end=reference_period_end,
                             # TODO: Add to scraper (HAPI-199)


### PR DESCRIPTION
Also simplify configurable scrapers setup a bit

@turnerm Regarding [your comment](https://humanitarian.atlassian.net/browse/HAPI-212?focusedCommentId=159945):

`select count(*) from org where name = 'Humanité & Inclusion';`
gives 1
`select count(*) from org where name = 'Medicus Mundi Sur';`
gives 1
`select count(*) from org where name = 'Bureau des Nations Unies pour la Coordination des Affaires Humanitaires';`
gives 1

`select count(*) from operational_presence;`
gives 9336

Should we rely on a database index to prevent duplicates rather than the manual check I've added here?