### PR TITLE
HAPI-185 org type module name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Remove duplicates from operational presence
+- Org type module name from schemas library
 
 ## [0.2.2] - 2023-10-06
 

--- a/src/hapi/pipelines/database/org_type.py
+++ b/src/hapi/pipelines/database/org_type.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Dict
 
-from hapi_schema.db_orgtype import DBOrgType
+from hapi_schema.db_org_type import DBOrgType
 from hdx.scraper.utilities.reader import Read
 from sqlalchemy.orm import Session
 


### PR DESCRIPTION
Small change to org type module name in this [views PR](https://github.com/OCHA-DAP/hapi-sqlalchemy-schema/pull/3). This should only be merged once the above PR has been released on PyPI. 