### PR TITLE
HAPI-230 DB export runs on tag push

### DIFF
--- a/.github/workflows/db_export.yaml
+++ b/.github/workflows/db_export.yaml
@@ -2,9 +2,9 @@ name: Database Export
 
 on:
   workflow_dispatch: # Add a run button on GitHub
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - "*"
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Pinned postgres docker image version in DB export GitHub action
 - Change sector mapping for erl to ERY
 
+## [0.4.2] = 2023-10-13
+
+### Fixed
+
+- DB Export GitHub action runs on tag push
+
 ## [0.4.1] - 2023-10-11
 
 ### Fixed


### PR DESCRIPTION
See https://humanitarian.atlassian.net/browse/HAPI-230 for some more info, but I'm running into a problem where running the DB export on publish ends up with a detached head checkout and thus committing a new version of the DB fails. I'm hoping that switching to a tag push will basically have the same effect but a proper commit will be checkout out. 