### PR TITLE
HAPI-134 add two more food security countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [0.6.0] - 2023-10-26
 
 ### Added
 
 - Minor unit tests
-- Food security and related tables for Mali
+- Food security and related tables for Burkina Faso, Chad, and Mali
 
 ## [0.5.5] - 2023-10-19
 

--- a/src/hapi/pipelines/app/pipelines.py
+++ b/src/hapi/pipelines/app/pipelines.py
@@ -116,6 +116,9 @@ class Pipelines:
             "operational_presence", "admintwo", adminlevel=self.admintwo
         )
         _create_configurable_scrapers(
+            "food_security", "adminone", adminlevel=self.adminone
+        )
+        _create_configurable_scrapers(
             "food_security", "admintwo", adminlevel=self.admintwo
         )
 

--- a/src/hapi/pipelines/configs/core.yaml
+++ b/src/hapi/pipelines/configs/core.yaml
@@ -3,8 +3,10 @@ commit_limit: 1000
 
 HAPI_countries:
   - AFG
+  - BFA
   - MLI
   - NGA
+  - TCD
 
 country_name_overrides:
   BOL: "Bolivia"

--- a/src/hapi/pipelines/configs/food_security.yaml
+++ b/src/hapi/pipelines/configs/food_security.yaml
@@ -98,6 +98,19 @@ food_security_default:
     - "#affected+ch+food+p5+num"
     - "#affected+ch+food+p3plus+num"
 
+food_security_adminone:
+  food_security_ch:
+    dataset: "cadre-harmonise"
+    format: "xlsx"
+    admin:
+      - ~
+      - "adm1_pcod2"
+    admin_exact: True
+    prefilter: "adm0_pcod3 in ['TCD'] and adm2_pcod2 is None"
+    filter_cols:
+      - "adm0_pcod3"
+      - "adm2_pcod2"
+
 food_security_admintwo:
   food_security_ch:
     dataset: "cadre-harmonise"
@@ -106,7 +119,6 @@ food_security_admintwo:
       - ~
       - "adm2_pcod2"
     admin_exact: True
-    # TODO: Figure out why this has to be in here
-    prefilter: "adm0_pcod3 in ['MLI']"
+    prefilter: "adm0_pcod3 in ['BFA', 'MLI', 'TCD']"
     filter_cols:
       - "adm0_pcod3"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -94,11 +94,11 @@ class TestHAPIPipelines:
                     pipelines.output()
 
                     count = session.scalar(select(func.count(DBLocation.id)))
-                    assert count == 3
+                    assert count == 5
                     count = session.scalar(select(func.count(DBAdmin1.id)))
-                    assert count == 84
+                    assert count == 122
                     count = session.scalar(select(func.count(DBAdmin2.id)))
-                    assert count == 1312
+                    assert count == 1465
                     count = session.scalar(select(func.count(DBDataset.id)))
                     assert count == 7
                     count = session.scalar(select(func.count(DBResource.id)))
@@ -126,4 +126,4 @@ class TestHAPIPipelines:
                     count = session.scalar(
                         select(func.count(DBFoodSecurity.id))
                     )
-                    assert count == 11724
+                    assert count == 37254


### PR DESCRIPTION
- I went with Burkina Faso and Chad, as these are the only two countries in the CH that have PCodes matching those in the gazetteer (in terms of zero padding)
- Chad actually does have admin1 specific entries. Thanks to Mike's filtering tip I've managed to get those to work. 
- As with the HAPI-133 PR, the tests are working on my machine, but not on GHA due to the hapi-schema branch requirements. Once HAPI-132 is closed and merged then the dependency can be changed and hopefully everything will work. 