### PR TITLE
Allow specifying countries per theme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "hapi-schema>= 0.6.0",
     "hdx-python-country>= 3.6.4",
     "hdx-python-database[postgresql]>= 1.2.9",
-    "hdx-python-scraper>= 2.3.4",
+    "hdx-python-scraper>= 2.3.5",
     "libhxl",
     "sqlalchemy"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ attrs==23.2.0
     #   jsonschema
 cachetools==5.3.2
     # via google-auth
-certifi==2023.11.17
+certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via cryptography
@@ -78,7 +78,7 @@ hdx-python-database[postgresql]==1.2.9
     # via
     #   hapi-pipelines (pyproject.toml)
     #   hdx-python-database
-hdx-python-scraper==2.3.4
+hdx-python-scraper==2.3.5
     # via hapi-pipelines (pyproject.toml)
 hdx-python-utilities==3.6.4
     # via
@@ -196,7 +196,7 @@ python-dateutil==2.8.2
     #   libhxl
 python-io-wrapper==0.3.1
     # via libhxl
-python-slugify==8.0.2
+python-slugify==8.0.3
     # via
     #   ckanapi
     #   frictionless

--- a/src/hapi/pipelines/app/__main__.py
+++ b/src/hapi/pipelines/app/__main__.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 from os import getenv, remove
 from os.path import exists
-from typing import List, Optional
+from typing import Dict, Optional
 
 from hdx.api.configuration import Configuration
 from hdx.database import Database
@@ -16,6 +16,7 @@ from hdx.utilities.dictandlist import args_to_dict
 from hdx.utilities.easy_logging import setup_logging
 from hdx.utilities.errors_onexit import ErrorsOnExit
 from hdx.utilities.path import temp_dir
+from hdx.utilities.typehint import ListTuple
 
 from hapi.pipelines._version import __version__
 from hapi.pipelines.app import (
@@ -73,8 +74,8 @@ def parse_args():
 def main(
     db_uri: Optional[str] = None,
     db_params: Optional[str] = None,
-    themes_to_run: Optional[List[str]] = None,
-    scrapers_to_run: Optional[List[str]] = None,
+    themes_to_run: Optional[Dict] = None,
+    scrapers_to_run: Optional[ListTuple[str]] = None,
     save: bool = False,
     use_saved: bool = False,
     **ignore,
@@ -86,7 +87,7 @@ def main(
     Args:
         db_uri (Optional[str]): Database connection URI. Defaults to None.
         db_params (Optional[str]): Database connection parameters. Defaults to None.
-        themes_to_run (Optional[ListTuple[str]]): Themes to run. Defaults to None (all themes).
+        themes_to_run (Optional[Dict[str]]): Themes to run. Defaults to None (all themes).
         scrapers_to_run (Optional[ListTuple[str]]): Scrapers to run. Defaults to None (all scrapers).
         save (bool): Whether to save state for testing. Defaults to False.
         use_saved (bool): Whether to use saved state for testing. Defaults to False.
@@ -163,7 +164,13 @@ if __name__ == "__main__":
     if db_uri and "://" not in db_uri:
         db_uri = f"postgresql://{db_uri}"
     if args.themes:
-        themes_to_run = args.themes.split(",")
+        themes_to_run = {}
+        for theme in args.themes.split(","):
+            theme_strs = theme.split(":")
+            if len(theme_strs) == 1:
+                themes_to_run[theme_strs[0]] = None
+            else:
+                themes_to_run[theme_strs[0]] = theme_strs[1]
     else:
         themes_to_run = None
     if args.scrapers:

--- a/src/hapi/pipelines/utilities/process_config_defaults.py
+++ b/src/hapi/pipelines/utilities/process_config_defaults.py
@@ -15,26 +15,6 @@ def add_defaults(config: Dict) -> Dict:
     return config
 
 
-def subset_scraper_countries(config: Dict, countries_to_remove: List) -> Dict:
-    countries_to_remove = [c.lower() for c in countries_to_remove]
-    for key in config:
-        scraper_name = key.rsplit("_")
-        if scraper_name[-1] not in ["national", "adminone", "admintwo"]:
-            continue
-        subkeys_to_delete = []
-        for subkey in config[key]:
-            subscraper_name = subkey.rsplit("_")
-            subscraper_country = list(
-                set(subscraper_name) & set(countries_to_remove)
-            )
-            if len(subscraper_country) == 0:
-                continue
-            subkeys_to_delete.append(subkey)
-        for subkey in subkeys_to_delete:
-            del config[key][subkey]
-    return config
-
-
 def _find_defaults(config: Dict) -> List:
     default_list = []
     for key in config:


### PR DESCRIPTION
themes_to_run is now an optional Dict from theme name to list of countries where None is all countries

scraper names must take the form: themename_iso_* eg. population_gtm, humanitarian_needs_afg_total if the iso3 is to be correctly obtained (index is taken from the end of "themename_" for 3 characters if the length is sufficient). 

Is this convention ok or is it potentially confusing to reply on it @b-j-mills ? One alternative is to add a field under each country scraper YAML to explicitly specify which country is being handled but that will make the YAML configuration longer eg.
```
  humanitarian_needs_afg_edu:
    country: "AFG"
    dataset: "afghanistan-humanitarian-needs-overview"
    resource: "afg_hno_pin_2024.xlsx"
    filename: "humanitarian_needs_afg.xlsx"
    format: "xlsx"
    sheet: "EDU"
    headers: 6
    ...
``` 
