### PR TITLE
Prevent phonetic matching of short names

### DIFF
--- a/src/hapi/pipelines/utilities/mappings.py
+++ b/src/hapi/pipelines/utilities/mappings.py
@@ -32,6 +32,8 @@ def get_code_from_name(
     code = code_mapping.get(name_clean)
     if code:
         return code, name_clean, False
+    if len(name) <= 5:
+        return None, name_clean, False
     names = list(code_lookup.keys())
     names_lower = [x.lower() for x in names]
     name_index = Phonetics().match(

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -95,3 +95,9 @@ def test_get_code_from_name():
         "sante",
         False,
     )
+    sector_lookup["cccm"] = "CCM"
+    assert get_code_from_name("CCS", sector_lookup, sector_map) == (
+        None,
+        "ccs",
+        False,
+    )


### PR DESCRIPTION
I found CCS was mapped to CCM causing a primary key violation. This simple PR prevents use of phonetic matching for names <=5 chars. Do you think this is reasonable @b-j-mills @turnerm ?