### PR TITLE
Enable schedule

### DIFF
--- a/.github/workflows/db_export.yaml
+++ b/.github/workflows/db_export.yaml
@@ -6,7 +6,7 @@ on:
     tags:
       - "*"
   schedule:
-    - cron: "0 0,12 * * *"
+    - cron: "2 22,11 * * *"
 
 jobs:
   build:

--- a/.github/workflows/db_export.yaml
+++ b/.github/workflows/db_export.yaml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - "*"
+  schedule:
+    - cron: "0 0,12 * * *"
 
 jobs:
   build:
@@ -63,3 +65,17 @@ jobs:
         with:
           name: warnings-errors
           path: warnings_errors.log
+
+      - name: Send mail
+        if: failure()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: ${{secrets.EMAIL_SERVER}}
+          server_port: ${{secrets.EMAIL_PORT}}
+          username: ${{secrets.EMAIL_USERNAME}}
+          password: ${{secrets.EMAIL_PASSWORD}}
+          subject: "FAILED: ${{github.repository}} database export job"
+          body: GitHub Actions database export job for ${{github.repository}} failed!
+          to: ${{secrets.EMAIL_LIST}}
+          from: ${{secrets.EMAIL_FROM}}
+          content_type: text/html

--- a/.github/workflows/db_export.yaml
+++ b/.github/workflows/db_export.yaml
@@ -2,9 +2,8 @@ name: Database Export
 
 on:
   workflow_dispatch: # Add a run button on GitHub
-  push:
-    tags:
-      - "*"
+  release:
+    types: [published]
   schedule:
     - cron: "2 22,11 * * *"
 


### PR DESCRIPTION
Since the prod database is running nightly, this run would just be to make sure all of the pipelines are working as expected and to sync the prod and “dev” exports.  What do you think of running it twice a day to cover all our time zones in case something fails?  I've specified 11 and 22 UTC (7am/6pm EST, 12am/1pm CEST, 10am/11pm NZST) but open to other times!

I also don’t have admin access to the repo - are all of the usual email secrets added?