### PR TITLE
Add cron schedule to tests

### DIFF
--- a/.github/workflows/run-python-tests.yaml
+++ b/.github/workflows/run-python-tests.yaml
@@ -12,6 +12,8 @@ on:
   pull_request:
     branches-ignore:
       - gh-pages
+  schedule:
+    - cron: "2 21 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
Run tests nightly to catch any errors due to package updates