### PR TITLE
HDXDSYS-883 Add fuzzy matching back in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.9.42] - 2024-08-01
+
+### Changed
+
+- Reenable fuzzy matching
+
 ## [0.9.41] - 2024-07-31
 
 ### Changed

--- a/src/hapi/pipelines/database/org_type.py
+++ b/src/hapi/pipelines/database/org_type.py
@@ -24,6 +24,7 @@ class OrgType(BaseUploader):
         super().__init__(session)
         self._datasetinfo = datasetinfo
         self.data = org_type_map
+        self.unmatched = []
 
     def populate(self):
         logger.info("Populating org type table")
@@ -67,4 +68,5 @@ class OrgType(BaseUploader):
         return get_code_from_name(
             name=org_type,
             code_lookup=self.data,
+            unmatched=self.unmatched,
         )

--- a/src/hapi/pipelines/database/sector.py
+++ b/src/hapi/pipelines/database/sector.py
@@ -24,6 +24,7 @@ class Sector(BaseUploader):
         super().__init__(session)
         self._datasetinfo = datasetinfo
         self.data = sector_map
+        self.unmatched = []
 
     def populate(self):
         logger.info("Populating sector table")
@@ -64,4 +65,5 @@ class Sector(BaseUploader):
         return get_code_from_name(
             name=sector,
             code_lookup=self.data,
+            unmatched=self.unmatched,
         )

--- a/src/hapi/pipelines/utilities/mappings.py
+++ b/src/hapi/pipelines/utilities/mappings.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 
 from hdx.location.phonetics import Phonetics
 from hdx.utilities.text import normalise
@@ -9,7 +9,8 @@ MATCH_THRESHOLD = 5
 def get_code_from_name(
     name: str,
     code_lookup: Dict[str, str],
-    fuzzy_match: bool = False,
+    unmatched: List[str],
+    fuzzy_match: bool = True,
 ) -> str | None:
     """
     Given a name (org type, sector, etc), return the corresponding code.
@@ -17,6 +18,7 @@ def get_code_from_name(
     Args:
         name (str): Name to match
         code_lookup (dict): Dictionary of official names and codes
+        unmatched (List[str]): List of unmatched names
         fuzzy_match (bool): Allow fuzzy matching or not
 
     Returns:
@@ -25,22 +27,27 @@ def get_code_from_name(
     code = code_lookup.get(name)
     if code:
         return code
+    if name in unmatched:
+        return None
     name_clean = normalise(name)
     code = code_lookup.get(name_clean)
     if code:
         code_lookup[name] = code
         return code
     if len(name) <= MATCH_THRESHOLD:
+        unmatched.append(name)
         return None
     if not fuzzy_match:
+        unmatched.append(name)
         return None
-    names = list(code_lookup.keys())
+    names = [x for x in code_lookup.keys() if len(x) > MATCH_THRESHOLD]
     name_index = Phonetics().match(
         possible_names=names,
         name=name,
         alternative_name=name_clean,
     )
     if name_index is None:
+        unmatched.append(name)
         return None
     code = code_lookup.get(names[name_index])
     if code:

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -39,6 +39,7 @@ def test_get_code_from_name_org_type():
             "NATIONAL_NGO",
             actual_org_type_lookup,
             [],
+            fuzzy_match=False,
         )
         == "441"
     )
@@ -47,15 +48,41 @@ def test_get_code_from_name_org_type():
             "COOPÉRATION_INTERNATIONALE",
             actual_org_type_lookup,
             [],
+            fuzzy_match=False,
         )
         is None
     )
-    assert get_code_from_name("NGO", actual_org_type_lookup, []) is None
+    unmatched = []
+    assert (
+        get_code_from_name(
+            "COOPÉRATION_INTERNATIONALE",
+            actual_org_type_lookup,
+            unmatched,
+            fuzzy_match=True,
+        )
+        is None
+    )
+    assert (
+        get_code_from_name(
+            "COOPÉRATION_INTERNATIONALE",
+            actual_org_type_lookup,
+            unmatched,
+            fuzzy_match=True,
+        )
+        is None
+    )
+    assert (
+        get_code_from_name(
+            "NGO", actual_org_type_lookup, [], fuzzy_match=False
+        )
+        is None
+    )
     assert (
         get_code_from_name(
             "International",
             actual_org_type_lookup,
             [],
+            fuzzy_match=False,
         )
         is None
     )
@@ -114,7 +141,18 @@ def test_get_code_from_name_sector():
         )
         == "LOG"
     )
-    assert get_code_from_name("CCCM", actual_sector_lookup, []) == "CCM"
-    assert get_code_from_name("Santé", actual_sector_lookup, []) == "HEA"
+    assert (
+        get_code_from_name("CCCM", actual_sector_lookup, [], fuzzy_match=False)
+        == "CCM"
+    )
+    assert (
+        get_code_from_name(
+            "Santé", actual_sector_lookup, [], fuzzy_match=False
+        )
+        == "HEA"
+    )
     actual_sector_lookup["cccm"] = "CCM"
-    assert get_code_from_name("CCS", actual_sector_lookup, []) is None
+    assert (
+        get_code_from_name("CCS", actual_sector_lookup, [], fuzzy_match=False)
+        is None
+    )

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -38,6 +38,7 @@ def test_get_code_from_name_org_type():
         get_code_from_name(
             "NATIONAL_NGO",
             actual_org_type_lookup,
+            [],
         )
         == "441"
     )
@@ -45,14 +46,16 @@ def test_get_code_from_name_org_type():
         get_code_from_name(
             "COOPÉRATION_INTERNATIONALE",
             actual_org_type_lookup,
+            [],
         )
         is None
     )
-    assert get_code_from_name("NGO", actual_org_type_lookup) is None
+    assert get_code_from_name("NGO", actual_org_type_lookup, []) is None
     assert (
         get_code_from_name(
             "International",
             actual_org_type_lookup,
+            [],
         )
         is None
     )
@@ -100,16 +103,18 @@ def test_get_code_from_name_sector():
     actual_sector_lookup = {normalise(k): v for k, v in sector_lookup.items()}
     actual_sector_lookup.update(sector_map)
     assert (
-        get_code_from_name("education", actual_sector_lookup, fuzzy_match=True)
+        get_code_from_name(
+            "education", actual_sector_lookup, [], fuzzy_match=True
+        )
         == "EDU"
     )
     assert (
         get_code_from_name(
-            "LOGISTIQUE", actual_sector_lookup, fuzzy_match=True
+            "LOGISTIQUE", actual_sector_lookup, [], fuzzy_match=True
         )
         == "LOG"
     )
-    assert get_code_from_name("CCCM", actual_sector_lookup) == "CCM"
-    assert get_code_from_name("Santé", actual_sector_lookup) == "HEA"
+    assert get_code_from_name("CCCM", actual_sector_lookup, []) == "CCM"
+    assert get_code_from_name("Santé", actual_sector_lookup, []) == "HEA"
     actual_sector_lookup["cccm"] = "CCM"
-    assert get_code_from_name("CCS", actual_sector_lookup) is None
+    assert get_code_from_name("CCS", actual_sector_lookup, []) is None


### PR DESCRIPTION
Only match against names > threshold
Keep track of unmatched names to avoid repeatedly trying to fuzzy match them

I tested by deleting some mappings in the core yaml file and the test ran and failed quite fast (rather than running forever)