### PR TITLE
HDXDSYS-1034 Update HAPI Pipelines for new package naming in HDX Python Scraper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,10 @@ requires-python = ">=3.8"
 
 dependencies = [
     "hapi-schema>=0.8.15",
-    "hdx-python-api>= 6.3.2",
-    "hdx-python-country>= 3.7.7",
+    "hdx-python-api>= 6.3.4",
+    "hdx-python-country>= 3.7.8",
     "hdx-python-database[postgresql]>= 1.3.1",
-    "hdx-python-scraper>= 2.4.1",
+    "hdx-python-scraper>= 2.5.0",
     "hdx-python-utilities>= 3.7.3",
     "libhxl",
     "sqlalchemy"

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,7 +67,7 @@ hdx-python-country==3.7.8
     #   hdx-python-scraper
 hdx-python-database==1.3.3
     # via hapi-pipelines (pyproject.toml)
-hdx-python-scraper==2.4.1
+hdx-python-scraper==2.5.0
     # via hapi-pipelines (pyproject.toml)
 hdx-python-utilities==3.7.3
     # via
@@ -77,9 +77,9 @@ hdx-python-utilities==3.7.3
     #   hdx-python-scraper
 humanize==4.10.0
     # via frictionless
-identify==2.6.0
+identify==2.6.1
     # via pre-commit
-idna==3.8
+idna==3.10
     # via
     #   email-validator
     #   requests
@@ -134,7 +134,7 @@ packaging==24.1
     # via pytest
 petl==1.7.15
     # via frictionless
-platformdirs==4.3.2
+platformdirs==4.3.3
     # via virtualenv
 pluggy==1.5.0
     # via pytest
@@ -146,9 +146,9 @@ pockets==0.9.1
     # via sphinxcontrib-napoleon
 pre-commit==3.8.0
     # via hapi-pipelines (pyproject.toml)
-psycopg==3.2.1
+psycopg==3.2.2
     # via hdx-python-database
-psycopg-binary==3.2.1
+psycopg-binary==3.2.2
     # via psycopg
 pyasn1==0.6.1
     # via
@@ -228,7 +228,7 @@ ruamel-yaml==0.18.6
     # via hdx-python-utilities
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-setuptools==74.1.2
+setuptools==75.0.0
     # via ckanapi
 shellingham==1.5.4
     # via typer
@@ -277,7 +277,7 @@ unidecode==1.3.8
     # via
     #   libhxl
     #   pyphonetics
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   libhxl
     #   requests

--- a/src/hapi/pipelines/app/__main__.py
+++ b/src/hapi/pipelines/app/__main__.py
@@ -12,8 +12,8 @@ from hdx.database.dburi import (
     get_params_from_connection_uri,
 )
 from hdx.facades.keyword_arguments import facade
-from hdx.scraper.utilities import string_params_to_dict
-from hdx.scraper.utilities.reader import Read
+from hdx.scraper.framework.utilities import string_params_to_dict
+from hdx.scraper.framework.utilities.reader import Read
 from hdx.utilities.dateparse import now_utc
 from hdx.utilities.dictandlist import args_to_dict
 from hdx.utilities.easy_logging import setup_logging

--- a/src/hapi/pipelines/app/pipelines.py
+++ b/src/hapi/pipelines/app/pipelines.py
@@ -4,8 +4,8 @@ from typing import Dict, Optional
 
 from hdx.api.configuration import Configuration
 from hdx.location.adminlevel import AdminLevel
-from hdx.scraper.runner import Runner
-from hdx.scraper.utilities.sources import Sources
+from hdx.scraper.framework.runner import Runner
+from hdx.scraper.framework.utilities.sources import Sources
 from hdx.utilities.errors_onexit import ErrorsOnExit
 from hdx.utilities.typehint import ListTuple
 from sqlalchemy.orm import Session

--- a/src/hapi/pipelines/database/currency.py
+++ b/src/hapi/pipelines/database/currency.py
@@ -4,7 +4,7 @@ from logging import getLogger
 
 from hapi_schema.db_currency import DBCurrency
 from hdx.api.configuration import Configuration
-from hdx.scraper.utilities.reader import Read
+from hdx.scraper.framework.utilities.reader import Read
 from sqlalchemy.orm import Session
 
 from .base_uploader import BaseUploader

--- a/src/hapi/pipelines/database/food_price.py
+++ b/src/hapi/pipelines/database/food_price.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 
 from dateutil.relativedelta import relativedelta
 from hapi_schema.db_food_price import DBFoodPrice
-from hdx.scraper.utilities.reader import Read
+from hdx.scraper.framework.utilities.reader import Read
 from hdx.utilities.dateparse import parse_date
 from sqlalchemy.orm import Session
 

--- a/src/hapi/pipelines/database/food_security.py
+++ b/src/hapi/pipelines/database/food_security.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional, Set
 from hapi_schema.db_food_security import DBFoodSecurity
 from hdx.api.configuration import Configuration
 from hdx.location.adminlevel import AdminLevel
-from hdx.scraper.utilities.reader import Read
+from hdx.scraper.framework.utilities.reader import Read
 from hdx.utilities.dateparse import parse_date
 from hdx.utilities.typehint import ListTuple
 from sqlalchemy.orm import Session

--- a/src/hapi/pipelines/database/humanitarian_needs.py
+++ b/src/hapi/pipelines/database/humanitarian_needs.py
@@ -5,7 +5,7 @@ from logging import getLogger
 
 from hapi_schema.db_humanitarian_needs import DBHumanitarianNeeds
 from hdx.api.configuration import Configuration
-from hdx.scraper.utilities.reader import Read
+from hdx.scraper.framework.utilities.reader import Read
 from hdx.utilities.dictandlist import dict_of_lists_add
 from hdx.utilities.text import get_numeric_if_possible
 from sqlalchemy.orm import Session

--- a/src/hapi/pipelines/database/locations.py
+++ b/src/hapi/pipelines/database/locations.py
@@ -3,7 +3,7 @@
 from hapi_schema.db_location import DBLocation
 from hdx.api.configuration import Configuration
 from hdx.location.country import Country
-from hdx.scraper.utilities.reader import Read
+from hdx.scraper.framework.utilities.reader import Read
 from hdx.utilities.dateparse import parse_date
 from sqlalchemy.orm import Session
 

--- a/src/hapi/pipelines/database/metadata.py
+++ b/src/hapi/pipelines/database/metadata.py
@@ -6,8 +6,8 @@ from hapi_schema.db_dataset import DBDataset
 from hapi_schema.db_resource import DBResource
 from hdx.data.dataset import Dataset
 from hdx.data.resource import Resource
-from hdx.scraper.runner import Runner
-from hdx.scraper.utilities.reader import Read
+from hdx.scraper.framework.runner import Runner
+from hdx.scraper.framework.utilities.reader import Read
 from sqlalchemy.orm import Session
 
 from .base_uploader import BaseUploader

--- a/src/hapi/pipelines/database/org.py
+++ b/src/hapi/pipelines/database/org.py
@@ -6,7 +6,7 @@ from os.path import join
 from typing import Dict, NamedTuple
 
 from hapi_schema.db_org import DBOrg
-from hdx.scraper.utilities.reader import Read
+from hdx.scraper.framework.utilities.reader import Read
 from hdx.utilities.dictandlist import write_list_to_csv
 from hdx.utilities.text import normalise
 from sqlalchemy.orm import Session

--- a/src/hapi/pipelines/database/org_type.py
+++ b/src/hapi/pipelines/database/org_type.py
@@ -4,7 +4,7 @@ import logging
 from typing import Dict
 
 from hapi_schema.db_org_type import DBOrgType
-from hdx.scraper.utilities.reader import Read
+from hdx.scraper.framework.utilities.reader import Read
 from hdx.utilities.text import normalise
 from sqlalchemy.orm import Session
 

--- a/src/hapi/pipelines/database/sector.py
+++ b/src/hapi/pipelines/database/sector.py
@@ -4,7 +4,7 @@ import logging
 from typing import Dict
 
 from hapi_schema.db_sector import DBSector
-from hdx.scraper.utilities.reader import Read
+from hdx.scraper.framework.utilities.reader import Read
 from hdx.utilities.text import normalise
 from sqlalchemy.orm import Session
 

--- a/src/hapi/pipelines/database/wfp_commodity.py
+++ b/src/hapi/pipelines/database/wfp_commodity.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 
 from hapi_schema.db_wfp_commodity import DBWFPCommodity
 from hapi_schema.utils.enums import CommodityCategory
-from hdx.scraper.utilities.reader import Read
+from hdx.scraper.framework.utilities.reader import Read
 from sqlalchemy.orm import Session
 
 from .base_uploader import BaseUploader

--- a/src/hapi/pipelines/database/wfp_market.py
+++ b/src/hapi/pipelines/database/wfp_market.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional
 
 from hapi_schema.db_wfp_market import DBWFPMarket
 from hdx.location.adminlevel import AdminLevel
-from hdx.scraper.utilities.reader import Read
+from hdx.scraper.framework.utilities.reader import Read
 from hdx.utilities.dictandlist import dict_of_dicts_add
 from sqlalchemy.orm import Session
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,7 +26,7 @@ from hapi_schema.db_wfp_market import DBWFPMarket
 from hapi_schema.views import prepare_hapi_views
 from hdx.api.configuration import Configuration
 from hdx.database import Database
-from hdx.scraper.utilities.reader import Read
+from hdx.scraper.framework.utilities.reader import Read
 from hdx.utilities.dateparse import parse_date
 from hdx.utilities.errors_onexit import ErrorsOnExit
 from hdx.utilities.path import temp_dir


### PR DESCRIPTION
This change is needed because I've updated package names in HDX Python Scraper to avoid namespace clashes. Please go ahead and merge it if you're ok with it.