### PR TITLE
Add mappings to food security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+
+## [0.10.14] - 2024-10-23
+
+### Fixed
+
+- Errors in some food security data p-code mappings
+
 ## [0.10.13] - 2024-10-17
 
 ### Added

--- a/src/hapi/pipelines/configs/core.yaml
+++ b/src/hapi/pipelines/configs/core.yaml
@@ -46,6 +46,12 @@ admin1:
     "CPV|Santo Antao": "CV06"
     "DJI|Djibouti Ville": "DJ04"
     "ETH|B. Gumuz": "ET06"
+    "GMB|Basse": "GM02"
+    "GMB|Brikama": "GM03"
+    "GMB|Janjanbureh": "GM04"
+    "GMB|Kerewan": "GM06"
+    "GMB|Kuntaur": "GM07"
+    "GMB|Mansa konko": "GM08"
     "HTI|Nord-Ouest": "HT09"
     "HTI|Sud": "HT07"
     "MMR|BagoWest": "MMR008"
@@ -99,6 +105,7 @@ admin2:
     "CD83|Territoire de LODJA": "CD8303"
     "CO08|Distrito Especial, Industrial Y Portuario De Barranquilla": "CO08001"
     "DOM|Santiago": "DO0303"
+    "DOM|Bahoruco": "DO0601"
     "ET01|C. TIGRAY": "ET0102"
     "ET01|NW. TIGRAY": "ET0101"
     "ET02|ZONE1": "ET0201"
@@ -130,6 +137,7 @@ admin2:
     "KAZ004|Almaty City area": "KAZ004002"
     "KAZ014|Aqtau City area": "KAZ014001"
     "KE010|Moyale": "KE010045"
+    "MG51|Toliara II": "MG51520"
     "ML07|Menaka": "ML1001"
     "MMR015|Laukkaing": "MMR015S002"
     "NE006|Tagazar": "NE006003"
@@ -258,6 +266,7 @@ admin2:
     "YE24|Craiter": "YE2407"
     "YE26|Medghal": "YE2603"
     "ZM105|Shibuyunji": "ZM101012"  # TODO: this unit is not getting picked up because of the mismatched admin1
+    "ZM109|Chirundu": "ZM105002"  # TODO: this unit is not getting picked up because of the mismatched admin1
 
   admin_name_replacements:
     "COD| city": ""

--- a/src/hapi/pipelines/configs/food_security.yaml
+++ b/src/hapi/pipelines/configs/food_security.yaml
@@ -34,7 +34,6 @@ food_security:
   # in "Area" (usually blank "Level 1" means "Area" is admin 1 rather than 2)
   adm2_only:
     - "DOM"
-    - "GMB"
     - "MWI"
     - "PSE"
     - "TZA"

--- a/src/hapi/pipelines/configs/food_security.yaml
+++ b/src/hapi/pipelines/configs/food_security.yaml
@@ -21,6 +21,7 @@ food_security:
     - "returnee"
     - " cluster "
     - " commune "
+    - " accessible"
 
   # This is where all "Areas" are non-admin units and so there is only admin 1
   # data available in "Level 1"


### PR DESCRIPTION
Upon closer inspection, I needed to make some changes to the new IPC p-code mappings.  I also added "accessible" to the patterns we should ignore to avoid any erroneous matching.